### PR TITLE
Handle "Privy not ready" error for TestFlight environment

### DIFF
--- a/frontend/components/LoginScreen.tsx
+++ b/frontend/components/LoginScreen.tsx
@@ -1,4 +1,5 @@
 import { useLogin } from '@privy-io/expo/ui';
+import { usePrivy } from '@privy-io/expo';
 import { useEffect, useState } from 'react';
 import { SafeAreaView } from 'react-native';
 import { Box } from '@/components/ui/box';
@@ -10,6 +11,7 @@ import { navigateToTabs } from '@/lib/session';
 
 export default function LoginScreen() {
   const { login } = useLogin();
+  const { logout } = usePrivy();
   const [error, setError] = useState('');
   const { isReady, user } = useAuth();
 
@@ -52,9 +54,14 @@ export default function LoginScreen() {
             size="lg"
             className="w-full mb-4"
             onPress={() =>
-              login({ loginMethods: ['email'] }).catch((err) =>
-                setError(String(err?.message ?? err))
-              )
+              login({ loginMethods: ['email'] }).catch((err) => {
+                logout();
+                setError(
+                  err?.message === 'Privy not ready'
+                    ? 'Please try again'
+                    : String(err?.message ?? err)
+                );
+              })
             }
           >
             <Ionicons


### PR DESCRIPTION
##  内容

"Privy not ready"が出た際に、Privyをログアウトして、config を初期化する

## 考察

"Privy not ready"の発生条件は
TestFlight環境内(詳しい発生条件はわからず)、または開発環境で`oth-auth.tsx`を任意で修正しhot reloadが発生した場合。

エラーの場所は
`node_modules/@privy-io/expo/dist/esm/ui.js`
で何らかの理由で、Privyの`client.app.getConfig()`が定義されていない場合に発生。

```
let u=o.app.getConfig();if(!u)return s.reject(new S("privy_not_ready","Privy is not ready"))
```

@privy-io/expoのテストコードが公開されておらず、詳しい理由はわからないので、 エラー発生時にprivyをlogoutして初期化させることで開発環境では再現しなくなった。

 TestFlightモードで確認する必要あり。
